### PR TITLE
Update AdvancedWidgetEditorInterface.php

### DIFF
--- a/code/extensions/AdvancedWidgetEditorInterface.php
+++ b/code/extensions/AdvancedWidgetEditorInterface.php
@@ -55,7 +55,11 @@ class AdvancedWidgetEditorInterface extends DataExtension {
             
             //Fix the gridstate field
             if($field instanceof GridField) {
-                $field->getState(false)->setName($name.'[GridState]');
+				if($readonly){
+					$field = ReadonlyField::create($field->getTitle);
+				}else {
+					$field->getState(false)->setName($name.'[GridState]');
+				}
             }
             
             


### PR DESCRIPTION
BUGFIX: Uncaught Exception: Object->__call(): the method 'fortemplate' does not exist on 'HasManyList'. 

If a gridfield in a widget is made readonly for example when viewing the history tab, or when using advancedworkflow the above error is produced. This corrects the issue by changing the gridfield to a ReadonlyField